### PR TITLE
fix(auth): login via Noroff API + store token and API key

### DIFF
--- a/js/api/client.js
+++ b/js/api/client.js
@@ -1,15 +1,26 @@
 import { getToken } from "../storage/token.js";
+import { CONFIG } from "./config.js";
+import { getApiKey } from "../storage/apiKey.js";
+
+
 
 export async function apiRequest(url, options = {}) {
   const headers = new Headers(options.headers || {});
   headers.set("Content-Type", "application/json");
 
-  const token = getToken();
-  if (token) {
-    headers.set("Authorization", `Bearer ${token}`);
-  }
 
-  const response = await fetch(url, { ...options, headers });
+  const token = getToken();
+  if (token) 
+    headers.set("Authorization", `Bearer ${token}`);
+
+
+  const apiKey = getApiKey();
+  if (apiKey) headers.set("X-Noroff-API-Key", apiKey);
+  
+
+  const fullUrl = url.startsWith("/") ? `${CONFIG.BASE_URL}${url}` : url;
+  const response = await fetch(fullUrl, { ...options, headers });
+
 
   const contentType = response.headers.get("content-type") || "";
   const payload = contentType.includes("application/json")

--- a/js/pages/login.js
+++ b/js/pages/login.js
@@ -1,9 +1,11 @@
 import { renderLayout } from "../components/layout.js";
 import { apiRequest } from "../api/client.js";
 import { setToken }  from "../storage/token.js";
+import { getApiKey, setApiKey } from "../storage/apiKey.js";
+import { CONFIG } from "../api/config.js";
+
 
 renderLayout();
-
 
 const root = document.getElementById("page-root");
 
@@ -83,16 +85,31 @@ form.addEventListener("submit", async (e) => {
   if (!validateLogin({ email, password })) return;
 
   try {
-    const res =await apiRequest("/auth/login", {
+    const res =await apiRequest(`${CONFIG.BASE_URL}/auth/login`, {
       method: "POST",
       body: JSON.stringify({ email, password }),    
-    })
+    });
 
-    const accessToken = res?.data?.accessToken;
-    if (!accessToken) throw new Error("login succeded but no access token returned");
+  const accessToken = res?.data?.accessToken;
+  if (!accessToken) throw new Error("login succeeded but no access token returned");
 
     setToken(accessToken);
 
+
+  
+  const existingKey = getApiKey();
+
+  if (!existingKey) {
+     const apiKeyRes = await apiRequest(`${CONFIG.BASE_URL}/auth/create-api-key`, {
+    method: "POST",
+    body: JSON.stringify({ name: "semester-exam-key" }),
+     });
+
+  const apiKey = apiKeyRes?.data?.key;
+  if (apiKey) {
+    setApiKey(apiKey);
+  }
+}
     window.location.href = "../index.html";
   } catch (error) {
     formError.textContent = error.message || "Login failed, please try again";

--- a/js/pages/register.js
+++ b/js/pages/register.js
@@ -1,5 +1,8 @@
 import { renderLayout } from "../components/layout.js";
 import { apiRequest } from "../api/client.js";
+import { CONFIG } from "../api/config.js";
+
+
 
 
 renderLayout();
@@ -103,10 +106,10 @@ form.addEventListener("submit", async (e) => {
   if (!validateRegister({ name, email, password })) return;
 
   try {
-    await apiRequest("/auth/register", {
+    await apiRequest(`${CONFIG.BASE_URL}/auth/register`, {
       method: "POST",
       body: JSON.stringify({ name, email, password }),    
-    })
+    });
 
     window.location.href = "./login.html";
   } catch (error) {

--- a/js/storage/apiKey.js
+++ b/js/storage/apiKey.js
@@ -1,0 +1,13 @@
+const API_KEY_STORAGE = "noroffApiKey";
+
+export function setApiKey(key) {
+  localStorage.setItem(API_KEY_STORAGE, key);
+}
+
+export function getApiKey() {
+  return localStorage.getItem(API_KEY_STORAGE);
+}
+
+export function clearApiKey() {
+  localStorage.removeItem(API_KEY_STORAGE);
+}


### PR DESCRIPTION
Option 1 (Best balance: clear + complete)

- Fixed auth requests to use Noroff v2 BASE_URL to avoid 405 errors.

- Implemented login flow to store accessToken in localStorage.

- Added API key creation and persistence for authenticated blog requests.

- Updated API client to attach Authorization and X-Noroff-API-Key headers automatically.