### PR TITLE
prevent JSON headers og GET requests

### DIFF
--- a/js/api/client.js
+++ b/js/api/client.js
@@ -6,17 +6,27 @@ import { getApiKey } from "../storage/apiKey.js";
 
 export async function apiRequest(url, options = {}) {
   const headers = new Headers(options.headers || {});
-  headers.set("Content-Type", "application/json");
+  
+  const hasBody = options.body !== null && options.body !== undefined;
+
+
+  const isFormData =
+    typeof FormData !== "undefined" && options.body instanceof FormData;
+  if (hasBody && !isFormData && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
 
 
   const token = getToken();
-  if (token) 
-    headers.set("Authorization", `Bearer ${token}`);
+  if (token) {
+        headers.set("Authorization", `Bearer ${token}`);
+}
 
 
   const apiKey = getApiKey();
-  if (apiKey) headers.set("X-Noroff-API-Key", apiKey);
-  
+  if (apiKey) {
+     headers.set("X-Noroff-API-Key", apiKey);
+}
 
   const fullUrl = url.startsWith("/") ? `${CONFIG.BASE_URL}${url}` : url;
   const response = await fetch(fullUrl, { ...options, headers });


### PR DESCRIPTION
Prevents forcing JSON headers on GET requests and avoids 
conflicts with FormData uploads. 

Keeps auth + API key injection intact.